### PR TITLE
Add support for token_usage and add automatic retry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 steamship==2.3.13
 openai==0.25.0
+tenacity==8.2.0
+tiktoken==0.2.0

--- a/src/api.py
+++ b/src/api.py
@@ -1,5 +1,6 @@
 """Default generation plugin for prompts."""
 import logging
+from collections import defaultdict
 from typing import Any, Dict, List, Optional, Type
 
 import openai
@@ -11,6 +12,15 @@ from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPlugin
 from steamship.plugin.outputs.block_and_tag_plugin_output import BlockAndTagPluginOutput
 from steamship.plugin.request import PluginRequest
 from steamship.plugin.tagger import Tagger
+from tenacity import (
+    after_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class PromptGenerationPlugin(Tagger):
@@ -22,18 +32,30 @@ class PromptGenerationPlugin(Tagger):
     """
 
     class PromptGenerationPluginConfig(Config):
-        openai_api_key: str = Field("", description="An openAI API key to use. If left default, will use Steamship's API key.")
-        max_words: int = Field(description="The maximum number of words to generate per request")
-        model: Optional[str] = Field("text-davinci-003", description="The OpenAI model to use.  Can be a pre-existing fine-tuned model.")
-        temperature: Optional[float] = Field(0.4, description="Controls randomness. Lower values produce higher likelihood / more predictable results; higher values produce more variety. Values between 0-1.")
-        top_p: Optional[int] = Field(1, description="Controls the nucleus sampling, where the model considers the results of the tokens with top_p probability mass. Values between 0-1.")
-        n_completions: Optional[int] = Field(1, description="How many completions to generate for each prompt.")
-        echo: Optional[bool] = Field(False, description= "Echo back the prompt in addition to the completion")
-        stop: Optional[str] = Field("", description="Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence. Value is comma separated string version of the sequence.")
-        presence_penalty: Optional[int] = Field(0, description="Control how likely the model will reuse words. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. Number between -2.0 and 2.0.")
-        frequency_penalty: Optional[int] = Field(0, description="Control how likely the model will reuse words. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. Number between -2.0 and 2.0.")
-        best_of: Optional[int] = Field(1, description="Generates best_of completions server-side and returns the \"best\" (the one with the highest log probability per token).")
-        moderate_output: bool = Field(True, description="Pass the generated output back through OpenAI's moderation endpoint and throw an exception if flagged.")
+        openai_api_key: str = Field("",
+                                    description="An openAI API key to use. If left default, will use Steamship's API key.")
+        max_tokens: int = Field(description="The maximum number of tokens to generate per request")
+        model_name: Optional[str] = Field("text-davinci-003",
+                                          description="The OpenAI model to use.  Can be a pre-existing fine-tuned model.")
+        temperature: Optional[float] = Field(0.4,
+                                             description="Controls randomness. Lower values produce higher likelihood / more predictable results; higher values produce more variety. Values between 0-1.")
+        top_p: Optional[int] = Field(1,
+                                     description="Controls the nucleus sampling, where the model considers the results of the tokens with top_p probability mass. Values between 0-1.")
+        n: Optional[int] = Field(1, description="How many completions to generate for each prompt.")
+        echo: Optional[bool] = Field(False, description="Echo back the prompt in addition to the completion")
+        stop: Optional[str] = Field("",
+                                    description="Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence. Value is comma separated string version of the sequence.")
+        presence_penalty: Optional[int] = Field(0,
+                                                description="Control how likely the model will reuse tokens. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. Number between -2.0 and 2.0.")
+        frequency_penalty: Optional[int] = Field(0,
+                                                 description="Control how likely the model will reuse tokens. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. Number between -2.0 and 2.0.")
+        best_of: Optional[int] = Field(1,
+                                       description="Generates best_of completions server-side and returns the \"best\" (the one with the highest log probability per token).")
+        moderate_output: bool = Field(True,
+                                      description="Pass the generated output back through OpenAI's moderation endpoint and throw an exception if flagged.")
+        max_retries: int = Field(6, description="Maximum number of retries to make when generating.")
+        request_timeout: Optional[float] = Field(600,
+                                                 description="Timeout for requests to OpenAI completion API. Default is 600 seconds.")
 
     @classmethod
     def config_cls(cls) -> Type[Config]:
@@ -42,59 +64,199 @@ class PromptGenerationPlugin(Tagger):
     config: PromptGenerationPluginConfig
 
     def __init__(
-        self,
-        client: Steamship = None,
-        config: Dict[str, Any] = None,
-        context: InvocationContext = None,
+            self,
+            client: Steamship = None,
+            config: Dict[str, Any] = None,
+            context: InvocationContext = None,
     ):
         super().__init__(client, config, context)
         openai.api_key = self.config.openai_api_key
 
-    def _complete_text(
-        self, text_prompts: List[str], suffix: Optional[str] = None, user: Optional[str] = None
-    ) -> List[List[str]]:
+    def completion_with_retry(self, **kwargs: Any) -> Any:
+        """Use tenacity to retry the completion call."""
+        min_seconds = 4
+        max_seconds = 10
 
-        stopwords = self.config.stop.split(",") \
-            if self.config.stop is not None and self.config.stop != "" \
+        # Wait 2^x * 1 second between each retry starting with
+        # 4 seconds, then up to 10 seconds, then 10 seconds afterwards
+
+        @retry(
+            reraise=True,
+            stop=stop_after_attempt(self.config.max_retries),
+            wait=wait_exponential(multiplier=1, min=min_seconds, max=max_seconds),
+            retry=(
+                    retry_if_exception_type(openai.error.Timeout)
+                    | retry_if_exception_type(openai.error.APIError)
+                    | retry_if_exception_type(openai.error.APIConnectionError)
+                    | retry_if_exception_type(openai.error.RateLimitError)
+            ),
+            after=after_log(logger, logging.DEBUG),
+        )
+        def _completion_with_retry(**kwargs: Any) -> Any:
+            return openai.Completion.create(**kwargs)
+
+        return _completion_with_retry(**kwargs)
+
+    @property
+    def _default_params(self) -> Dict[str, Any]:
+        return {
+            "max_tokens": self.config.max_tokens,
+            "engine": self.config.model_name,
+            "temperature": self.config.temperature,
+            "top_p": self.config.top_p,
+            "n": self.config.n,
+            "echo": self.config.echo,
+            "presence_penalty": self.config.presence_penalty,
+            "frequency_penalty": self.config.frequency_penalty,
+            "best_of": self.config.best_of,
+            "request_timeout": self.config.request_timeout
+
+        }
+
+    def _get_num_tokens(self, text: str) -> int:
+        """Calculate num tokens with tiktoken package."""
+        try:
+            import tiktoken
+        except ImportError:
+            raise ValueError(
+                "Could not import tiktoken python package. "
+                "This is needed in order to calculate get_num_tokens. "
+                "Please it install it with `pip install tiktoken`."
+            )
+        encoder = "gpt2"
+        if self.config.model_name in ("text-davinci-003", "text-davinci-002"):
+            encoder = "p50k_base"
+        if self.config.model_name.startswith("code"):
+            encoder = "p50k_base"
+        # create a GPT-3 encoder instance
+        enc = tiktoken.get_encoding(encoder)
+
+        # encode the text using the GPT-3 encoder
+        tokenized_text = enc.encode(text)
+
+        # calculate the number of tokens in the encoded text
+        return len(tokenized_text)
+
+    def modelname_to_contextsize(self, modelname: str) -> int:
+        """Calculate the maximum number of tokens possible to generate for a model.
+
+        text-davinci-003: 4,097 tokens
+        text-curie-001: 2,048 tokens
+        text-babbage-001: 2,048 tokens
+        text-ada-001: 2,048 tokens
+        code-davinci-002: 8,000 tokens
+        code-cushman-001: 2,048 tokens
+
+        Args:
+            modelname: The modelname we want to know the context size for.
+
+        Returns:
+            The maximum context size
+
+        Example:
+            .. code-block:: python
+
+                max_tokens = openai.modelname_to_contextsize("text-davinci-003")
+        """
+        if modelname == "text-davinci-003":
+            return 4097
+        elif modelname == "text-curie-001":
+            return 2048
+        elif modelname == "text-babbage-001":
+            return 2048
+        elif modelname == "text-ada-001":
+            return 2048
+        elif modelname == "code-davinci-002":
+            return 8000
+        elif modelname == "code-cushman-001":
+            return 2048
+        else:
+            return 4097
+
+    def _max_tokens_for_prompt(self, prompt: str) -> int:
+        """Calculate the maximum number of tokens possible to generate for a prompt.
+
+        Args:
+            prompt: The prompt to pass into the model.
+
+        Returns:
+            The maximum number of tokens to generate for a prompt.
+
+        Example:
+            .. code-block:: python
+
+                max_tokens = openai.max_token_for_prompt("Tell me a joke.")
+        """
+        num_tokens = self._get_num_tokens(prompt)
+
+        # get max context size for model by name
+        max_size = self.modelname_to_contextsize(self.config.model_name)
+        return max_size - num_tokens
+
+    def _complete_text(
+            self, prompts: List[str],
+            stop: Optional[List[str]] = None,
+            suffix: Optional[str] = None,
+            user: Optional[str] = None
+    ) -> (List[List[str]], Dict[str, int]):
+
+        if self.config.max_tokens == -1:
+            if len(prompts) != 1:
+                raise ValueError(
+                    "max_tokens set to -1 not supported for multiple inputs."
+                )
+            self.config.max_tokens = self._max_tokens_for_prompt(prompts[0])
+
+        if stop is not None:
+            if self.config.stop:
+                raise ValueError("`stop` found in both the input and default configuration.")
+        else:
+            stop = self.config.stop
+
+        stop = stop.split(",") \
+            if stop is not None and stop != "" \
             else None
         logging.info(f"Making OpenAI generation call on behalf of user with id: {user}")
         """Call the API to generate the next section of text."""
-        completion = openai.Completion.create(
-            prompt=text_prompts,
-            suffix=suffix,
-            user=user or "",
-            max_tokens=self.config.max_words,
-            engine=self.config.model,
-            temperature=self.config.temperature,
-            top_p=self.config.top_p,
-            n=self.config.n_completions,
-            echo=self.config.echo,
-            stop=stopwords,
-            presence_penalty=self.config.presence_penalty,
-            frequency_penalty=self.config.frequency_penalty,
-            best_of=self.config.best_of,
+
+        invocation_params = {
+            "prompt": prompts,
+            "suffix": suffix,
+            "user": user or "",
+            "stop": stop,
+            **self._default_params  # Note: stops are not invocation params just yet
+        }
+        completion = self.completion_with_retry(
+            **invocation_params,
         )
         result = []
-        for i in range(0, len(completion.choices), self.config.n_completions):
-            result.append([choice.text for choice in completion.choices[i:i+self.config.n_completions]])
-        return result
+        token_usage = defaultdict(int)
+        for i in range(0, len(completion.choices), self.config.n):
+            result.append([choice.text for choice in completion.choices[i:i + self.config.n]])
+        for key, usage in completion["usage"].items():
+            token_usage[key] += usage
+        return result, token_usage
 
-    def _flagged(self, responses: List[List[str]]) -> bool:
+    @staticmethod
+    def _flagged(responses: List[List[str]]) -> bool:
         input_text = "\n\n".join([text for sublist in responses for text in sublist])
         moderation = openai.Moderation.create(input=input_text)
         return moderation['results'][0]['flagged']
 
     def run(
-        self, request: PluginRequest[BlockAndTagPluginInput]
+            self, request: PluginRequest[BlockAndTagPluginInput]
     ) -> InvocableResponse[BlockAndTagPluginOutput]:
         """Run the text generator against all Blocks of text."""
 
         file = request.data.file
         prompts = [block.text for block in file.blocks]
         user_id = self.context.user_id if self.context is not None else "testing"
-        generated_texts = self._complete_text(prompts, user=user_id)
+        generated_texts, token_usage = self._complete_text(prompts=prompts, user=user_id)
         if self.config.moderate_output and self._flagged(generated_texts):
-            raise SteamshipError("At least one of the responses was flagged as inappropriate by OpenAI. You may disable this behavior in the plugin by setting moderate_output=False in the PluginInstance config.")
+            raise SteamshipError(
+                "At least one of the responses was flagged as inappropriate by OpenAI. "
+                "You may disable this behavior in the plugin by setting moderate_output=False "
+                "in the PluginInstance config.")
         for block, options in zip(file.blocks, generated_texts):
             for option in options:
                 block.tags.append(
@@ -104,5 +266,11 @@ class PromptGenerationPlugin(Tagger):
                         value={TagValueKey.STRING_VALUE: option},
                     )
                 )
+
+        file.tags.append(
+            Tag(kind="token_usage",
+                name="token_usage",
+                value=token_usage)
+        )
 
         return InvocableResponse(data=BlockAndTagPluginOutput(file=file))

--- a/steamship.json
+++ b/steamship.json
@@ -1,10 +1,10 @@
 {
 	"type": "plugin",
-	"handle": "gpt-3",
-	"version": "0.0.11",
-	"description": "Complete prompts and generate text with OpenAI.",
-	"author": "",
-	"entrypoint": "src.api.handler",
+	"handle": "openai",
+	"version": "0.0.4",
+	"description": "",
+	"author": "Enias",
+	"entrypoint": "Unused",
 	"public": true,
 	"plugin": {
 		"isTrainable": false,
@@ -12,7 +12,10 @@
 		"type": "tagger"
 	},
 	"build_config": {
-		"ignore": []
+		"ignore": [
+			"tests",
+			"examples"
+		]
 	},
 	"configTemplate": {
 		"openai_api_key": {
@@ -20,12 +23,12 @@
 			"description": "An openAI API key to use. If left default, will use Steamship's API key.",
 			"default": ""
 		},
-		"max_words": {
+		"max_tokens": {
 			"type": "number",
-			"description": "The maximum number of words to generate per request",
+			"description": "The maximum number of tokens to generate per request",
 			"default": null
 		},
-		"model": {
+		"model_name": {
 			"type": "string",
 			"description": "The OpenAI model to use.  Can be a pre-existing fine-tuned model.",
 			"default": "text-davinci-003"
@@ -40,7 +43,7 @@
 			"description": "Controls the nucleus sampling, where the model considers the results of the tokens with top_p probability mass. Values between 0-1.",
 			"default": 1
 		},
-		"n_completions": {
+		"n": {
 			"type": "number",
 			"description": "How many completions to generate for each prompt.",
 			"default": 1
@@ -57,12 +60,12 @@
 		},
 		"presence_penalty": {
 			"type": "number",
-			"description": "Control how likely the model will reuse words. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. Number between -2.0 and 2.0.",
+			"description": "Control how likely the model will reuse tokens. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. Number between -2.0 and 2.0.",
 			"default": 0
 		},
 		"frequency_penalty": {
 			"type": "number",
-			"description": "Control how likely the model will reuse words. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. Number between -2.0 and 2.0.",
+			"description": "Control how likely the model will reuse tokens. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. Number between -2.0 and 2.0.",
 			"default": 0
 		},
 		"best_of": {
@@ -74,29 +77,35 @@
 			"type": "boolean",
 			"description": "Pass the generated output back through OpenAI's moderation endpoint and throw an exception if flagged.",
 			"default": true
+		},
+		"max_retries": {
+			"type": "number",
+			"description": "Maximum number of retries to make when generating.",
+			"default": 6
+		},
+		"request_timeout": {
+			"type": "number",
+			"description": "Timeout for requests to OpenAI completion API. Default is 600 seconds.",
+			"default": 600
 		}
 	},
 	"steamshipRegistry": {
-		"tagline": "Complete prompts and generate text.",
-		"tagline2": "Combine with other models and SteamshipQL to add memory.",
-		"usefulFor": "Adding on-demand replies and suggestions to users.",
+		"tagline": "Complete prompts and generate text with OpenAI.",
+		"tagline2": null,
+		"usefulFor": null,
 		"videoUrl": null,
-		"githubUrl": "https://github.com/steamship-plugins/prompt-generation-default",
+		"githubUrl": null,
 		"demoUrl": null,
 		"blogUrl": null,
 		"jupyterUrl": null,
-		"authorGithub": "dkolas",
-		"authorName": "dkolas",
-		"authorEmail": "developers@steamship.com",
-		"authorTwitter": "",
-		"authorUrl": "",
+		"authorGithub": "EniasCailliau",
+		"authorName": "steamship",
+		"authorEmail": null,
+		"authorTwitter": null,
+		"authorUrl": null,
 		"tags": [
-			"NLP",
-			"OpenAI",
-			"GPT-3",
-			"Prompt Completion",
-			"LLM",
-			"GPT"
+			"openai",
+			"gpt-3"
 		]
 	}
 }

--- a/steamship.json
+++ b/steamship.json
@@ -1,10 +1,10 @@
 {
 	"type": "plugin",
 	"handle": "openai",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "",
-	"author": "Enias",
-	"entrypoint": "Unused",
+	"author": "",
+	"entrypoint": "src.api.handler",
 	"public": true,
 	"plugin": {
 		"isTrainable": false,
@@ -94,18 +94,22 @@
 		"tagline2": null,
 		"usefulFor": null,
 		"videoUrl": null,
-		"githubUrl": null,
+		"githubUrl": "https://github.com/steamship-plugins/prompt-generation-default",
 		"demoUrl": null,
 		"blogUrl": null,
 		"jupyterUrl": null,
-		"authorGithub": "EniasCailliau",
-		"authorName": "steamship",
-		"authorEmail": null,
+		"authorGithub": "dkolas",
+		"authorName": "dkolas",
+		"authorEmail": "developers@steamship.com",
 		"authorTwitter": null,
 		"authorUrl": null,
 		"tags": [
-			"openai",
-			"gpt-3"
+			"NLP",
+			"OpenAI",
+			"GPT-3",
+			"Prompt Completion",
+			"LLM",
+			"GPT"
 		]
 	}
 }

--- a/test/config.json
+++ b/test/config.json
@@ -1,6 +1,6 @@
 {
-  "max_words" : 100,
+  "max_tokens" : 100,
   "stop": "tst,test",
-  "n_completions": 2,
+  "n": 2,
   "best_of": 2
 }

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -8,7 +8,7 @@ import pytest
 from steamship import Block, File, PluginInstance, Steamship, TaskState
 from steamship.data import GenerationTag, TagKind, TagValueKey
 
-GENERATOR_HANDLE = "gpt-3"
+GENERATOR_HANDLE = "openai"
 ENVIRONMENT = "prod"
 
 

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -21,10 +21,20 @@ def test_tagger():
     assert response.status.state is TaskState.succeeded
     assert response.data is not None
     assert response.data.file is not None
-    assert response.data.file.blocks is not None
-    assert len(response.data.file.blocks) == 1
 
-    tags = response.data.file.blocks[0].tags
+    file = response.data.file
+
+    assert file.tags is not None
+    assert len(file.tags) == 1
+    for file_tag in file.tags:
+        assert file_tag.kind == "token_usage"
+        assert file_tag.value is not None
+        assert isinstance(file_tag.value, dict)
+
+    assert file.blocks is not None
+    assert len(file.blocks) == 1
+
+    tags = file.blocks[0].tags
     assert len(tags) == config.get("best_of", 1)
     for tag in tags:
         assert tag.kind == TagKind.GENERATION
@@ -36,10 +46,11 @@ def test_tagger():
 
 def test_tagger_multiblock():
     config = json.load(Path("config.json").open())
-    config['n_completions'] = 3
-    config['best_of'] = config['n_completions']
+    config['n'] = 3
+    config['best_of'] = config['n']
     tagger = PromptGenerationPlugin(config=config)
-    file = File(id="foo", blocks=[Block(text="Let's count: one two three"), Block(text="The primary colors are: red blue")])
+    file = File(id="foo",
+                blocks=[Block(text="Let's count: one two three"), Block(text="The primary colors are: red blue")])
     request = PluginRequest(data=BlockAndTagPluginInput(file=file))
     response = tagger.run(request)
 
@@ -49,10 +60,10 @@ def test_tagger_multiblock():
     assert response.data.file.blocks is not None
     assert len(response.data.file.blocks) == 2
 
-    assert len(response.data.file.blocks[0].tags) == config['n_completions']
-    first_block_completion = response.data.file.blocks[0].tags[0].value[TagValueKey.STRING_VALUE]
+    assert len(response.data.file.blocks[0].tags) == config['n']
+    first_block_completion = response.data.file.blocks[0].tags[0].value[TagValueKey.STRING_VALUE].lower()
     assert "four" in first_block_completion
 
-    assert len(response.data.file.blocks[1].tags) == config['n_completions']
-    second_block_completion = response.data.file.blocks[1].tags[0].value[TagValueKey.STRING_VALUE]
+    assert len(response.data.file.blocks[1].tags) == config['n']
+    second_block_completion = response.data.file.blocks[1].tags[0].value[TagValueKey.STRING_VALUE].lower()
     assert "yellow" in second_block_completion


### PR DESCRIPTION
# This PR: 

- [x] Adds support for automatic max_token scaling 
- [x] Adds support for automatic retry of failed requests to OpenAI 
- [x] Renames some of the config parameters to be named the same as the OpenAI spec. 
- [x] Expose token_usage stats returned by OpenAI


# The intent of this PR: 

* Offer similar features as `langchain.llms.OpenAI` 
* Avoid redundant API docs by following OpenAI's naming convention 
* Expose token_usage so that `steamship_langchain.llms.OpenAI` can offer the same functionality as `langchain.llms.OpenAI`